### PR TITLE
add dependabot schedule.day

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+      day: "saturday"


### PR DESCRIPTION
This pull request includes a small change to the `.github/dependabot.yml` file. The change updates the schedule for Dependabot to run on Saturdays instead of the default day.