### PR TITLE
Update snapshot and fix year in footer

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/__test__/__snapshots__/home.snap.test.tsx.snap
+++ b/src/__test__/__snapshots__/home.snap.test.tsx.snap
@@ -80,7 +80,7 @@ exports[`Home renders unchanged 1`] = `
       >
         <p>
           © 
-          2024
+          2025
            hamatatsu
         </p>
       </div>


### PR DESCRIPTION
Update the reference link in the TypeScript configuration comment and change the year in the footer from 2024 to 2025.